### PR TITLE
Add place plugin

### DIFF
--- a/plugins/single_plugins/meson.build
+++ b/plugins/single_plugins/meson.build
@@ -13,3 +13,4 @@ rotator       = shared_module('rotator',       'rotator.cpp',       include_dire
 apps_logger   = shared_module('apps-logger',   'apps-logger.cpp',   include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
 window_rules  = shared_module('window-rules',  'window-rules.cpp',  include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
 center_view   = shared_module('center-view',   'center-view.cpp',   include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
+place         = shared_module('place',         'place.cpp',         include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')

--- a/plugins/single_plugins/place.cpp
+++ b/plugins/single_plugins/place.cpp
@@ -1,0 +1,106 @@
+#include <view.hpp>
+#include <core.hpp>
+#include <workspace-manager.hpp>
+#include <signal-definitions.hpp>
+
+class wayfire_place_window : public wayfire_plugin_t
+{
+	signal_callback_t created_cb;
+	signal_callback_t workarea_changed_cb;
+	wf_option placement_mode;
+	int cascade_x, cascade_y;
+
+	public:
+	void init(wayfire_config *config)
+	{
+		created_cb = [=] (signal_data *data)
+		{
+			auto view = get_signaled_view(data);
+
+			if (view->role != WF_VIEW_ROLE_TOPLEVEL ||
+				view->parent || view->fullscreen ||
+				view->maximized)
+				return;
+
+			auto workarea = output->workspace->get_workarea();
+			auto mode = placement_mode->as_string();
+
+			if (mode == "cascade")
+				cascade(view, workarea);
+			else if (mode == "random")
+				random(view, workarea);
+			else
+				center(view, workarea);
+		};
+
+		workarea_changed_cb = [=] (signal_data *data)
+		{
+			auto workarea = output->workspace->get_workarea();
+			cascade_x = workarea.x;
+			cascade_y = workarea.y;
+		};
+
+		auto section = config->get_section("place");
+		placement_mode = section->get_option("mode", "center");
+
+		output->connect_signal("reserved-workarea", &workarea_changed_cb);
+		output->connect_signal("map-view", &created_cb);
+	}
+
+	void cascade(wayfire_view &view, wf_geometry workarea)
+	{
+		wf_geometry window = view->get_wm_geometry();
+
+		if (cascade_x + window.width > workarea.x + workarea.width ||
+			cascade_y + window.height > workarea.y + workarea.height)
+		{
+			cascade_x = workarea.x;
+			cascade_y = workarea.y;
+		}
+
+		view->move(cascade_x, cascade_y);
+
+		cascade_x += workarea.width * .03;
+		cascade_y += workarea.height * .03;
+	}
+
+	void random(wayfire_view &view, wf_geometry workarea)
+	{
+		wf_geometry window = view->get_wm_geometry();
+		wf_geometry area;
+		int pos_x, pos_y;
+
+		area.x = workarea.x;
+		area.y = workarea.y;
+		area.width = workarea.width - window.width;
+		area.height = workarea.height - window.height;
+
+		if (area.width < 0 || area.height < 0)
+		{
+			center(view, workarea);
+			return;
+		}
+
+		pos_x = rand() % area.width + area.x;
+		pos_y = rand() % area.height + area.y;
+
+		view->move(pos_x, pos_y);
+		
+	}
+
+	void center(wayfire_view &view, wf_geometry workarea)
+	{
+		wf_geometry window = view->get_wm_geometry();
+		window.x = workarea.x + (workarea.width / 2) - (window.width / 2);
+		window.y = workarea.y + (workarea.height / 2) - (window.height / 2);
+		view->move(window.x, window.y);
+	}
+};
+
+extern "C"
+{
+	wayfire_plugin_t *newInstance() 
+	{
+		return new wayfire_place_window();
+	}
+}


### PR DESCRIPTION
Add a basic window placement plugin with three placement modes.
This plugin was based off of the center-view plugin by Adrian
Vovk. It contains the same code as center-view for the center
placement mode. The valid mode config keys are cascade, center
and random.